### PR TITLE
Fix GET/price_hist endpoint 

### DIFF
--- a/docker_files/docker_setup.sh
+++ b/docker_files/docker_setup.sh
@@ -8,7 +8,7 @@
 ########################## --- MAIN ROUTER API --- ##########################
 
 ### build the images (specifying the Dockerfile location)
-docker image build . -t ramirohr/tradingbot:1.0.8 -f docker_files/tradingbot_api/Dockerfile
+docker image build . -t ramirohr/tradingbot:1.0.9 -f docker_files/tradingbot_api/Dockerfile
 
 
 ### run docker container & link ports & mount volumes
@@ -17,7 +17,7 @@ docker container run --name bot_api -p 8000:8000 -d \
 --volume "$(pwd -W)/data:/data" \
 --volume "$(pwd -W)/models:/models" \
 #--volume "$(pwd -W)/src:/src" \
-ramirohr/tradingbot:1.0.8
+ramirohr/tradingbot:1.0.9
 
 ### launch the docker compose
 # docker-compose up

--- a/docker_files/tradingbot_api/src/data/make_dataset.py
+++ b/docker_files/tradingbot_api/src/data/make_dataset.py
@@ -137,6 +137,7 @@ class getData:
                 cursor = collection.find()
                 
                 df_temp = pd.DataFrame(list(cursor))
+                df_temp.drop(columns=['_id'], inplace=True)
                 
                 # take the last entry as a start date for the update
                 self.startDate = df_temp.iloc[-1,0]

--- a/kubernetes/tb_deployment.yml
+++ b/kubernetes/tb_deployment.yml
@@ -34,7 +34,7 @@ spec:
 
         ## Router api container:
         - name: cont-router-api
-          image: ramirohr/tradingbot:1.0.8
+          image: ramirohr/tradingbot:1.0.9
           ports:
             - containerPort: 8000
 


### PR DESCRIPTION
Added a line to drop '_id' col when retrieving df from database in getKlines method (docker_files/tradingbot_api/src/data/make_dataset.py) 

Updated docker_setup and deployment.yml with new tradingbot:1.0.9 image (shared on Dockerhub)